### PR TITLE
fix : mixin for iron-icon

### DIFF
--- a/paper-icon-button.html
+++ b/paper-icon-button.html
@@ -117,6 +117,7 @@ Custom property | Description | Default
       iron-icon {
         --iron-icon-width: 100%;
         --iron-icon-height: 100%;
+        @apply(--iron-icon);
       }
     </style>
 


### PR DESCRIPTION
mixin for `iron-icon` added. Now the internal `iron-icon` can be styled.
